### PR TITLE
Doc and misc improvements

### DIFF
--- a/bench/bench.cabal
+++ b/bench/bench.cabal
@@ -1,5 +1,5 @@
 cabal-version:      2.4
-name:               compare
+name:               bench
 version:            0.1.0.0
 
 common warnings

--- a/script/script.cabal
+++ b/script/script.cabal
@@ -2,7 +2,7 @@ cabal-version:      2.4
 name:               script
 version:            0.1.0.0
 
-executable compare
+executable script
     ghc-options: -Wall
 
     build-depends:

--- a/src/Regex/Base.hs
+++ b/src/Regex/Base.hs
@@ -25,7 +25,6 @@ module Regex.Base
   , R.anySingle
   , R.single
   , R.satisfy
-  , R.foldable
   , R.foldlMany
   , R.foldlManyMin
   , R.Many(..)
@@ -66,7 +65,7 @@ import qualified Regex.Internal.Parser as P
 --
 -- The functions @prepareParser@, @stepParser@, and @finishParser@ grant
 -- a large amount of control over the parsing process, making it possible to
--- parse monadically, or in a branching manner, or even both.
+-- parse in a resumable or even branching manner.
 --
 -- As a simpler alternative to the trio of functions above, @parseFoldr@ can be
 -- used on any sequence type that can be folded over.

--- a/src/Regex/Internal/Parser.hs
+++ b/src/Regex/Internal/Parser.hs
@@ -327,7 +327,7 @@ localU = Unique . (+1) . unUnique
 -- Running a Parser
 --------------------
 
--- | The state maintained by a parser.
+-- | The state maintained for parsing.
 data ParserState c a = ParserState
   { psNeed :: !(NeedCList c a)
   , psResult :: !(Maybe a)

--- a/src/Regex/Internal/Regex.hs
+++ b/src/Regex/Internal/Regex.hs
@@ -10,7 +10,6 @@ module Regex.Internal.Regex
   , anySingle
   , single
   , satisfy
-  , foldable
 
   , foldlMany
   , foldlManyMin
@@ -159,10 +158,6 @@ single !c = satisfy (c==)
 -- | Parse any @c@.
 anySingle :: RE c c
 anySingle = token Just
-
--- | Parse the given chunk of @c@s.
-foldable :: (Foldable f, Eq c) => f c -> RE c (f c)
-foldable xs = xs <$ foldr ((*>) . single) (pure ()) xs
 
 ---------
 -- Many

--- a/src/Regex/Internal/Text.hs
+++ b/src/Regex/Internal/Text.hs
@@ -394,7 +394,6 @@ reParse re = let !p = P.compile re in parse p
 -- | \(O(mn \log m)\). Parse a @Text@ with a @ParserText@.
 parse :: ParserText a -> Text -> Maybe a
 parse = P.parseFoldr tokenFoldr
-{-# INLINE parse #-}
 
 -- | \(O(mn \log m)\). Parse a @Text@ with a @ParserText@. Calls 'error' on
 -- parse failure.
@@ -524,7 +523,7 @@ toReplace re = liftA2 f manyTextMin re <*> manyText
 --              \<*> digits 2 \<* sep
 --              \<*> digits 4
 -- @
--- >>> replaceMany date "01/01/1970, 01-04-1990, 03.07.2011"
+-- >>> replaceAll date "01/01/1970, 01-04-1990, 03.07.2011"
 -- "1970-01-01, 1990-04-01, 2011-07-03"
 --
 replaceAll :: REText Text -> Text -> Text

--- a/src/Regex/List.hs
+++ b/src/Regex/List.hs
@@ -109,10 +109,11 @@ import qualified Regex.Internal.List as L
 -- == Recursive definitions
 --
 -- It is not possible to define a @RE@ recursively. If it were permitted, it
--- would be capable of parsing more than [regular languages](https://en.wikipedia.org/wiki/Regular_language).
--- Unfortunately, there is no way to make it impossible to write such a regex
--- in the first place. So it must be avoided by the programmer. As an example,
--- avoid this:
+-- would be capable of parsing more than
+-- [regular languages](https://en.wikipedia.org/wiki/Regular_language).
+-- Unfortunately, there is no good way\* to make it impossible to write such
+-- a regex in the first place. So it must be avoided by the programmer. As an
+-- example, avoid this:
 --
 -- @
 -- re :: RE Char [String]
@@ -132,6 +133,9 @@ import qualified Regex.Internal.List as L
 -- If you find that your regex is impossible to write without recursion,
 -- you are attempting to parse a non-regular language! You need a more powerful
 -- parser than what this library has to offer.
+--
+-- \* [Unlifted datatypes](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/primitives.html#unlifted-datatypes)
+-- can serve this purpose but they are too inconvenient to work with.
 --
 -- == Laziness
 --
@@ -201,6 +205,6 @@ import qualified Regex.Internal.List as L
 --   \(O(m)\) memory is required.
 --
 -- This applies even as subcomponents. So, any subcomponent @RE@ of a larger
--- @RE@ that is only recognizing a section of the list is cheap in terms of
+-- @RE@ that is only recognizing a section of the list is cheaper in terms of
 -- memory.
 --

--- a/src/Regex/Text.hs
+++ b/src/Regex/Text.hs
@@ -109,10 +109,11 @@ import qualified Regex.Internal.Text as T
 -- == Recursive definitions
 --
 -- It is not possible to define a @RE@ recursively. If it were permitted, it
--- would be capable of parsing more than [regular languages](https://en.wikipedia.org/wiki/Regular_language).
--- Unfortunately, there is no way to make it impossible to write such a regex
--- in the first place. So it must be avoided by the programmer. As an example,
--- avoid this:
+-- would be capable of parsing more than
+-- [regular languages](https://en.wikipedia.org/wiki/Regular_language).
+-- Unfortunately, there is no good way\* to make it impossible to write such
+-- a regex in the first place. So it must be avoided by the programmer. As an
+-- example, avoid this:
 --
 -- @
 -- re :: REText [Text]
@@ -132,6 +133,9 @@ import qualified Regex.Internal.Text as T
 -- If you find that your regex is impossible to write without recursion,
 -- you are attempting to parse a non-regular language! You need a more powerful
 -- parser than what this library has to offer.
+--
+-- \* [Unlifted datatypes](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/primitives.html#unlifted-datatypes)
+-- can serve this purpose but they are too inconvenient to work with.
 --
 -- == Laziness
 --
@@ -201,9 +205,9 @@ import qualified Regex.Internal.Text as T
 --   \(O(m)\) memory is required.
 -- * To parse some slice of the input @Text@ (using one of @manyText@,
 --   @manyTextOf@, etc.), memory required is \(O(1)\). For @toMatch r@, memory
---   required is \(O(m')\) where \(m'\) is the size of @r@.
+--   required is \(O(m' \min (m',n))\) where \(m'\) is the size of @r@.
 --
 -- This applies even as subcomponents. So, any subcomponent @RE@ of a larger
--- @RE@ that is only recognizing text or parsing a slice is cheap in terms of
+-- @RE@ that is only recognizing text or parsing a slice is cheaper in terms of
 -- memory.
 --


### PR DESCRIPTION
* Fix cabal target names
* Remove Base.foldable. I don't think it's useful.
* Remove inline from Text.parse. Not beneficial other than maybe eliminating the Maybe.
* Documentation fixes and improvements