### PR TITLE
Remove unnecessary bytestring dep

### DIFF
--- a/parser-regex.cabal
+++ b/parser-regex.cabal
@@ -52,7 +52,6 @@ library
 
     build-depends:
         base >= 4.15 && < 5.0
-      , bytestring >= 0.10.12 && < 0.13
       , containers >= 0.6.4 && < 0.8
       , deepseq >= 1.4.5 && < 1.6
       , ghc-bignum >= 1.1 && < 1.4
@@ -68,7 +67,6 @@ test-suite test
 
     build-depends:
         base
-      , bytestring
       , containers
       , parser-regex
       , QuickCheck >= 2.14.3 && < 2.15


### PR DESCRIPTION
Why did I add this ¯\\\_(ツ)\_/¯