### PR TITLE
Allow worker/wrapper for down, downNode, up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Next
+
+* Performance improvements
+  * Fix a pessimization due to boxity analysis in GHC >= 9.4. Improves parsing
+    time by up to 23%.
+
 ### 0.2.0.2 -- 2024-03-15
 
 * Compatibility with [MicroHs](https://github.com/augustss/MicroHs)


### PR DESCRIPTION
StepState allocations are entirely eliminated.
Parsing times for the (somewhat) realistic benchmarks improve by up to 23% and allocations by 39%.

Fixes #51

---

Benchmarks on GHC 9.10.1

```
Name                                                        Time - - - - - - - -    Allocated - - - - -
                                                                 A       B     %         A       B     %
compare.English replace all.parser-regex S                  115 ms  106 ms   -8%    364 MB  235 MB  -35%
compare.English replace all.parser-regex T                   69 ms   69 ms   +0%    326 MB  197 MB  -39%
compare.English text 1.parser-regex S                        79 ms   67 ms  -14%    322 MB  193 MB  -39%
compare.English text 1.parser-regex T                        57 ms   47 ms  -16%    335 MB  206 MB  -38%
compare.English text 2.parser-regex S                        50 ms   39 ms  -21%    300 MB  199 MB  -33%
compare.English text 2.parser-regex T                        49 ms   40 ms  -19%    296 MB  194 MB  -34%
compare.Exponential backtracking.parser-regex S              16 μs  9.7 μs  -37%     88 KB   58 KB  -33%
compare.Exponential backtracking.parser-regex T              16 μs   10 μs  -36%     83 KB   52 KB  -37%
compare.Parse CaseFolding.txt.parser-regex S                 59 ms   47 ms  -21%    305 MB  215 MB  -29%
compare.Parse CaseFolding.txt.parser-regex T                 58 ms   44 ms  -23%    308 MB  219 MB  -29%
compare.Parse URI.parser-regex S                             79 ms   64 ms  -18%    404 MB  276 MB  -31%
compare.Parse URI.parser-regex T                             70 ms   54 ms  -23%    418 MB  290 MB  -30%
parser-regex.IntTree.foldlMany' anySingle.foldrTree         3.5 ms  3.4 ms   -1%     30 MB   21 MB  -28%
parser-regex.IntTree.foldlMany' anySingle.foldrTreeStack    3.8 ms  3.2 ms  -17%     27 MB   16 MB  -41%
parser-regex.Text.bigRegex.bigRegex                          58 ms   45 ms  -22%    246 MB  170 MB  -31%
parser-regex.Text.chainl.bigExpr                            202 ms  143 ms  -29%    1.4 GB  970 MB  -31%
parser-regex.Text.chainr.bigExpr                            202 ms  142 ms  -29%    1.4 GB  970 MB  -31%
parser-regex.Text.char.a                                     28 ms   25 ms  -11%    244 MB  130 MB  -46%
parser-regex.Text.charIgnoreCase.aA                          37 ms   35 ms   -5%    275 MB  160 MB  -41%
parser-regex.Text.many, linear time.many                     61 ms   56 ms   -7%    298 MB  183 MB  -38%
parser-regex.Text.many, linear time.manyMin                  64 ms   59 ms   -7%    336 MB  183 MB  -45%
parser-regex.Text.many, linear time.manyr                    60 ms   57 ms   -4%    313 MB  198 MB  -36%
parser-regex.Text.many, linear time.toMatch many             36 ms   32 ms  -12%    320 MB  206 MB  -35%
parser-regex.Text.many, linear time.toMatch manyMin          39 ms   37 ms   -5%    359 MB  206 MB  -42%
parser-regex.Text.many, linear time.toMatch manyr            36 ms   32 ms  -12%    320 MB  206 MB  -35%
parser-regex.Text.many, linear time.withMatch many           83 ms   80 ms   -3%    481 MB  366 MB  -23%
parser-regex.Text.many, linear time.withMatch manyMin        86 ms   84 ms   -2%    519 MB  366 MB  -29%
parser-regex.Text.many, linear time.withMatch manyr          85 ms   83 ms   -3%    496 MB  381 MB  -23%
parser-regex.Text.naturalDec.bigNumberDec                   130 ms  114 ms  -12%    905 MB  600 MB  -33%
parser-regex.Text.naturalHex.bigNumberHex                   134 ms  115 ms  -13%    908 MB  603 MB  -33%
parser-regex.Text.text.a                                     21 ms   17 ms  -17%    167 MB  121 MB  -27%
parser-regex.Text.textIgnoreCase.aA                          44 ms   36 ms  -18%    263 MB  217 MB  -17%
parser-regex.Text.wordDecN.manyNumbers                      8.2 ms  5.8 ms  -28%     53 MB   42 MB  -21%
parser-regex.Text.wordHexN.manyNumbersHex                   5.9 ms  4.3 ms  -26%     38 MB   30 MB  -21%
parser-regex.Text.wordRangeDec.compile.manyRanges            41 ms   43 ms   +5%    407 MB  407 MB   +0%
parser-regex.Text.wordRangeDec.parse.manyNumbers             70 ms   53 ms  -24%    448 MB  346 MB  -22%
parser-regex.Text.wordRangeHex.compile.manyRanges            45 ms   46 ms   +2%    762 MB  762 MB   +0%
parser-regex.Text.wordRangeHex.parse.manyNumbersHex          41 ms   32 ms  -22%    261 MB  201 MB  -23%
```