### PR TITLE
Use Solo to control strictness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Next
 
+* Breaking changes—`Internal` modules only
+  * Changes to internal representations
 * Performance improvements
   * Fix a pessimization due to boxity analysis in GHC >= 9.4. Improves parsing
     time by up to 23%.

--- a/parser-regex.cabal
+++ b/parser-regex.cabal
@@ -52,6 +52,7 @@ library
         Regex.Internal.Debug
         Regex.Internal.Parser
         Regex.Internal.Regex
+        Regex.Internal.Solo
         Regex.Internal.Text
         Regex.Internal.Unique
 

--- a/src/Regex/Internal/Debug.hs
+++ b/src/Regex/Internal/Debug.hs
@@ -22,7 +22,7 @@ import Data.Maybe (isJust)
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IM
 
-import Regex.Internal.Regex (RE(..), Strictness(..), Greediness(..))
+import Regex.Internal.Regex (RE(..), Greediness(..))
 import Regex.Internal.Parser (Node(..), Parser(..))
 import Regex.Internal.Unique (Unique(..))
 import qualified Regex.Internal.CharSet as CS
@@ -44,15 +44,15 @@ reToDot ma re0 = execM $ do
     go :: forall b. RE c b -> M Id
     go re = case re of
       RToken t -> new $ labelToken "RToken" t ma
-      RFmap st _ re1 ->
-        withNew (str "RFmap" <+> dispsSt st) $ \i ->
+      RFmap _ re1 ->
+        withNew (str "RFmap") $ \i ->
           go re1 >>= writeEdge i
       RFmap_ _ re1 ->
         withNew (str "RFmap_") $ \i ->
           go re1 >>= writeEdge i
       RPure _ -> new (str "RPure")
-      RLiftA2 st _ re1 re2 ->
-        withNew (str "RLiftA2" <+> dispsSt st) $ \i -> do
+      RLiftA2 _ re1 re2 ->
+        withNew (str "RLiftA2") $ \i -> do
           go re1 >>= writeEdge i
           go re2 >>= writeEdge i
       REmpty -> new (str "REmpty")
@@ -60,8 +60,8 @@ reToDot ma re0 = execM $ do
         withNew (str "RAlt") $ \i -> do
           go re1 >>= writeEdge i
           go re2 >>= writeEdge i
-      RFold st gr _ _ re1 ->
-        withNew (str "RFold" <+> dispsSt st <+> dispsGr gr) $ \i ->
+      RFold gr _ _ re1 ->
+        withNew (str "RFold" <+> dispsGr gr) $ \i ->
           go re1 >>= writeEdge i
       RMany _ _ _ _ re1 ->
         withNew (str "RMany") $ \i ->
@@ -84,8 +84,8 @@ parserToDot ma p0 = execM $ do
     go :: forall b. Parser c b -> M Id
     go p = case p of
       PToken t -> new $ labelToken "PToken" t ma
-      PFmap st _ re1 ->
-        withNew (str "PFmap" <+> dispsSt st) $ \i ->
+      PFmap _ re1 ->
+        withNew (str "PFmap") $ \i ->
           go re1 >>= writeEdge i
       PFmap_ node ->
         withNew (str "PFmap_") $ \i -> do
@@ -94,8 +94,8 @@ parserToDot ma p0 = execM $ do
           writeLn (str "}")
           writeEdge i j
       PPure _ -> new (str "PPure")
-      PLiftA2 st _ re1 re2 ->
-        withNew (str "PLiftA2" <+> dispsSt st) $ \i -> do
+      PLiftA2 _ re1 re2 ->
+        withNew (str "PLiftA2") $ \i -> do
           go re1 >>= writeEdge i
           go re2 >>= writeEdge i
       PEmpty -> new (str "PEmpty")
@@ -107,11 +107,11 @@ parserToDot ma p0 = execM $ do
       PMany _ _ _ _ _ re1 ->
         withNew (str "PMany") $ \i ->
           go re1 >>= writeEdge i
-      PFoldGr _ st _ _ re1 ->
-        withNew (str "PFoldGr" <+> dispsSt st) $ \i ->
+      PFoldGr _ _ _ re1 ->
+        withNew (str "PFoldGr") $ \i ->
           go re1 >>= writeEdge i
-      PFoldMn _ st _ _ re1 ->
-        withNew (str "PFoldMn" <+> dispsSt st) $ \i ->
+      PFoldMn _ _ _ re1 ->
+        withNew (str "PFoldMn") $ \i ->
           go re1 >>= writeEdge i
 
     goNode :: forall b. Node c b -> StateT (IntMap Id) M Id
@@ -157,11 +157,6 @@ instance Semigroup Str where
 
 instance Monoid Str where
   mempty = Str id
-
-dispsSt :: Strictness -> Str
-dispsSt st = case st of
-  Strict -> str "S"
-  NonStrict -> str "NS"
 
 dispsGr :: Greediness -> Str
 dispsGr gr = case gr of

--- a/src/Regex/Internal/List.hs
+++ b/src/Regex/Internal/List.hs
@@ -50,10 +50,11 @@ import Data.CharSet (CharSet)
 import qualified Data.CharSet as CS
 import Regex.Internal.Parser (Parser)
 import qualified Regex.Internal.Parser as P
-import Regex.Internal.Regex (RE(..), Greediness(..), Strictness(..))
+import Regex.Internal.Regex (RE(..), Greediness(..))
 import qualified Regex.Internal.Regex as R
 import qualified Regex.Internal.Num as RNum
 import qualified Regex.Internal.Generated.CaseFold as CF
+import Regex.Internal.Solo (Solo, mkSolo', solo)
 
 ------------------------
 -- REs and combinators
@@ -232,29 +233,28 @@ toMatch = fmap dToL . toMatch_
 toMatch_ :: RE c b -> RE c (DList c)
 toMatch_ re = case re of
   RToken t -> RToken (\c -> singletonD c <$ t c)
-  RFmap _ _ re1 -> toMatch_ re1
+  RFmap _ re1 -> toMatch_ re1
   RFmap_ _ re1 -> toMatch_ re1
   RPure _ -> RPure mempty
-  RLiftA2 _ _ re1 re2 -> RLiftA2 Strict (<>) (toMatch_ re1) (toMatch_ re2)
+  RLiftA2 _ re1 re2 -> R.liftA2' (<>) (toMatch_ re1) (toMatch_ re2)
   REmpty -> REmpty
   RAlt re1 re2 -> RAlt (toMatch_ re1) (toMatch_ re2)
-  RMany _ _ _ _ re1 -> RFold Strict Greedy (<>) mempty (toMatch_ re1)
-  RFold _ gr _ _ re1 -> RFold Strict gr (<>) mempty (toMatch_ re1)
+  RMany _ _ _ _ re1 -> R.foldlMany' (<>) mempty (toMatch_ re1)
+  RFold gr _ _ re1 -> case gr of
+    Greedy -> R.foldlMany' (<>) mempty (toMatch_ re1)
+    Minimal -> R.foldlManyMin' (<>) mempty (toMatch_ re1)
 
 data WithMatch c a = WM !(DList c) a
 
-instance Functor (WithMatch c) where
-  fmap f (WM t x) = WM t (f x)
+fmapWM :: (a -> Solo b) -> WithMatch c a -> WithMatch c b
+fmapWM f (WM t x) = solo (WM t) (f x)
 
-fmapWM' :: (a -> b) -> WithMatch c a -> WithMatch c b
-fmapWM' f (WM t x) = WM t $! f x
+pureWM :: a -> WithMatch c a
+pureWM = WM mempty
 
-instance Applicative (WithMatch c) where
-  pure = WM mempty
-  liftA2 f (WM t1 x) (WM t2 y) = WM (t1 <> t2) (f x y)
-
-liftA2WM' :: (a1 -> a2 -> b) -> WithMatch c a1 -> WithMatch c a2 -> WithMatch c b
-liftA2WM' f (WM t1 x) (WM t2 y) = WM (t1 <> t2) $! f x y
+liftA2WM
+  :: (a1 -> a2 -> Solo b) -> WithMatch c a1 -> WithMatch c a2 -> WithMatch c b
+liftA2WM f (WM t1 x) (WM t2 y) = solo (WM (t1 <> t2)) (f x y)
 
 -- | Rebuild the @RE@ to include the matched section of the list alongside the
 -- result.
@@ -263,28 +263,23 @@ withMatch = R.fmap' (\(WM cs x) -> (dToL cs, x)) . go
   where
     go :: RE c b -> RE c (WithMatch c b)
     go re = case re of
-      RToken t -> RToken (\c -> WM (singletonD c) <$> t c)
-      RFmap st f re1 ->
-        let g = case st of
-              Strict -> fmapWM' f
-              NonStrict -> fmap f
-        in RFmap Strict g (go re1)
-      RFmap_ b re1 -> RFmap Strict (flip WM b) (toMatch_ re1)
-      RPure b -> RPure (pure b)
-      RLiftA2 st f re1 re2 ->
-        let g = case st of
-              Strict -> liftA2WM' f
-              NonStrict -> Ap.liftA2 f
-        in RLiftA2 Strict g (go re1) (go re2)
-      REmpty -> REmpty
-      RAlt re1 re2 -> RAlt (go re1) (go re2)
+      RToken t -> R.token (\c -> WM (singletonD c) <$> t c)
+      RFmap f re1 -> R.fmap' (fmapWM f) (go re1)
+      RFmap_ b re1 -> R.fmap' (flip WM b) (toMatch_ re1)
+      RPure b -> pure (pureWM b)
+      RLiftA2 f re1 re2 -> R.liftA2' (liftA2WM f) (go re1) (go re2)
+      REmpty -> Ap.empty
+      RAlt re1 re2 -> go re1 <|> go re2
       RMany f1 f2 f z re1 ->
-        RMany (fmapWM' f1) (fmapWM' f2) (liftA2WM' f) (pure z) (go re1)
-      RFold st gr f z re1 ->
-        let g = case st of
-              Strict -> liftA2WM' f
-              NonStrict -> Ap.liftA2 f
-        in RFold Strict gr g (pure z) (go re1)
+        RMany
+          (\x -> mkSolo' (fmapWM f1 x))
+          (\x -> mkSolo' (fmapWM f2 x))
+          (\x y -> mkSolo' (liftA2WM f x y))
+          (pureWM z)
+          (go re1)
+      RFold gr f z re1 -> case gr of
+        Greedy -> R.foldlMany' (liftA2WM f) (pureWM z) (go re1)
+        Minimal -> R.foldlManyMin' (liftA2WM f) (pureWM z) (go re1)
 
 ----------
 -- Parse

--- a/src/Regex/Internal/Solo.hs
+++ b/src/Regex/Internal/Solo.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UnliftedNewtypes #-}
+#endif
+
+module Regex.Internal.Solo
+  ( Solo
+  , mkSolo
+  , mkSolo'
+  , solo
+  , flipSolo
+  ) where
+
+mkSolo :: a -> Solo a
+mkSolo' :: a -> Solo a
+solo :: (a -> b) -> Solo a -> b
+flipSolo :: Solo a -> (a -> b) -> b
+
+#ifdef __GLASGOW_HASKELL__
+newtype Solo a = Solo (# a #)
+mkSolo x = Solo (# x #)
+mkSolo' !x = Solo (# x #)
+solo f (Solo (# x #)) = f x
+flipSolo (Solo (# x #)) f = f x
+#else
+data Solo a = Solo a
+mkSolo = Solo
+mkSolo' !x = Solo x
+solo f (Solo x) = f x
+flipSolo (Solo x) f = f x
+#endif


### PR DESCRIPTION
...instead of a strict/non-strict flag, effectively making the behavior a property of the function. This reduces the memory footprints of REs, Parsers, Conts, and makes the code nicer.

Benchmarks using GHC 9.10.1 show up to 15% reduction in allocations, though the running times remains pretty much the same.