### PR TITLE
Depend on ghc-bignum again

### DIFF
--- a/parser-regex.cabal
+++ b/parser-regex.cabal
@@ -81,7 +81,8 @@ library
 
     if impl(ghc)
         build-depends:
-            primitive >= 0.7.3 && < 0.10
+            ghc-bignum >= 1.1 && < 1.4
+          , primitive >= 0.7.3 && < 0.10
 
     if impl(mhs)
         build-depends:


### PR DESCRIPTION
GHC.Num.Natural will be removed from base, see CLC #359.

https://github.com/haskell/core-libraries-committee/issues/359